### PR TITLE
fixes #4 and removes pageItemPosterHTML from optional content

### DIFF
--- a/MucowTags.json
+++ b/MucowTags.json
@@ -148,10 +148,7 @@
     "pageItemPosterHTML": {
         "attributes": [],
         "context": [
-            "HTMLWidget", 
-            "value", 
-            "trueVal",
-            "falseVal"
+            "HTMLWidget"
         ]
     },
     "parameters": {
@@ -215,6 +212,7 @@
     },
     "value": {
         "attributes": [
+            "disableOptions", 
             "label", 
             "name"
         ],

--- a/mucow.xsd
+++ b/mucow.xsd
@@ -7,7 +7,6 @@
       <xs:element name="bodyBeginHTML" type="xs:string" minOccurs="0" maxOccurs="1" />
       <xs:element name="pageItemHTML" type="xs:string" minOccurs="0" maxOccurs="1" />
       <xs:element name="bodyEndHTML" type="xs:string" minOccurs="0" maxOccurs="1" />
-      <xs:element name="pageItemPosterHTML" type="xs:string" minOccurs="0" maxOccurs="1" />
     </xs:choice>
   </xs:group>
   <xs:group name="parameters">
@@ -229,6 +228,7 @@
           </xs:complexType>
         </xs:element>
         <xs:group ref="contents" />
+        <xs:element name="pageItemPosterHTML" type="xs:string" minOccurs="0" maxOccurs="1" />
       </xs:choice>
       <xs:attribute name="name" type="xs:string" use="required"/>
       <xs:attribute name="formatNumber" use="required" >

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "title": "MuCow Language Support",
     "description": "Support for MUSE widget markup (MuCow)",
     "homepage": "https://github.com/Adobe-Muse/brackets-mucow-language-support",
-    "version": "0.4.71",
+    "version": "0.4.75",
     "author": "Adobe",
     "license": "MIT",
     "engines": {


### PR DESCRIPTION
Fixes #4 
Removes `pageItemPosterHTML` from optional tags
